### PR TITLE
Switch API level to 610

### DIFF
--- a/c_src/atom_names.h
+++ b/c_src/atom_names.h
@@ -28,7 +28,6 @@ ATOM_MAP(not_found);
 
 ATOM_MAP(erlfdb_error);
 ATOM_MAP(erlfdb_future);
-ATOM_MAP(erlfdb_cluster);
 ATOM_MAP(erlfdb_database);
 ATOM_MAP(erlfdb_transaction);
 
@@ -39,6 +38,7 @@ ATOM_MAP(invalid_future_type);
 ATOM_MAP(local_address);
 ATOM_MAP(cluster_file);
 ATOM_MAP(trace_enable);
+ATOM_MAP(trace_format);
 ATOM_MAP(trace_roll_size);
 ATOM_MAP(trace_max_logs_size);
 ATOM_MAP(trace_log_group);
@@ -63,10 +63,6 @@ ATOM_MAP(external_client_directory);
 ATOM_MAP(disable_local_client);
 ATOM_MAP(disable_client_statistics_logging);
 ATOM_MAP(enable_slow_task_profiling);
-
-
-// Cluster Options
-// There aren't any...
 
 
 // Database Options

--- a/c_src/fdb.h
+++ b/c_src/fdb.h
@@ -13,7 +13,7 @@
 #ifndef ERLFDB_FDB_H
 #define ERLFDB_FDB_H
 
-#define FDB_API_VERSION 600
+#define FDB_API_VERSION 610
 #include <foundationdb/fdb_c.h>
 
 #endif // Included fdb.h

--- a/c_src/resources.c
+++ b/c_src/resources.c
@@ -14,7 +14,6 @@
 
 
 ErlNifResourceType* ErlFDBFutureRes;
-ErlNifResourceType* ErlFDBClusterRes;
 ErlNifResourceType* ErlFDBDatabaseRes;
 ErlNifResourceType* ErlFDBTransactionRes;
 
@@ -32,18 +31,6 @@ erlfdb_init_resources(ErlNifEnv* env)
             NULL
         );
     if(ErlFDBFutureRes == NULL) {
-        return 0;
-    }
-
-    ErlFDBClusterRes = enif_open_resource_type(
-            env,
-            NULL,
-            "erlfdb_cluster",
-            erlfdb_cluster_dtor,
-            ERL_NIF_RT_CREATE,
-            NULL
-        );
-    if(ErlFDBClusterRes == NULL) {
         return 0;
     }
 
@@ -86,17 +73,6 @@ erlfdb_future_dtor(ErlNifEnv* env, void* obj)
 
     if(f->msg_env != NULL) {
         enif_free_env(f->msg_env);
-    }
-}
-
-
-void
-erlfdb_cluster_dtor(ErlNifEnv* env, void* obj)
-{
-    ErlFDBCluster* c = (ErlFDBCluster*) obj;
-
-    if(c->cluster != NULL) {
-        fdb_cluster_destroy(c->cluster);
     }
 }
 

--- a/c_src/resources.h
+++ b/c_src/resources.h
@@ -20,7 +20,6 @@
 
 
 extern ErlNifResourceType* ErlFDBFutureRes;
-extern ErlNifResourceType* ErlFDBClusterRes;
 extern ErlNifResourceType* ErlFDBDatabaseRes;
 extern ErlNifResourceType* ErlFDBTransactionRes;
 
@@ -31,8 +30,6 @@ typedef enum _ErlFDBFutureType
     ErlFDB_FT_VOID,
     ErlFDB_FT_VERSION,
     ErlFDB_FT_KEY,
-    ErlFDB_FT_CLUSTER,
-    ErlFDB_FT_DATABASE,
     ErlFDB_FT_VALUE,
     ErlFDB_FT_STRING_ARRAY,
     ErlFDB_FT_KEYVALUE_ARRAY
@@ -49,12 +46,6 @@ typedef struct _ErlFDBFuture
     ERL_NIF_TERM msg_ref;
     bool cancelled;
 } ErlFDBFuture;
-
-
-typedef struct _ErlFDBCluster
-{
-    FDBCluster* cluster;
-} ErlFDBCluster;
 
 
 typedef struct _ErlFDBDatabase
@@ -74,7 +65,6 @@ typedef struct _ErlFDBTransaction
 
 int erlfdb_init_resources(ErlNifEnv* env);
 void erlfdb_future_dtor(ErlNifEnv* env, void* obj);
-void erlfdb_cluster_dtor(ErlNifEnv* env, void* obj);
 void erlfdb_database_dtor(ErlNifEnv* env, void* obj);
 void erlfdb_transaction_dtor(ErlNifEnv* env, void* obj);
 

--- a/src/erlfdb.app.src
+++ b/src/erlfdb.app.src
@@ -18,7 +18,7 @@
     {maintainers, ["Paul J. Davis"]},
     {links, [{"GitHub", "https://github.com/cloudant-labs/couchdb-erlfdb"}]},
     {env, [
-        {api_version, 600},
+        {api_version, 610},
         {network_options, []}
     ]}
 ]}.

--- a/src/erlfdb.erl
+++ b/src/erlfdb.erl
@@ -142,8 +142,7 @@ open() ->
 
 
 open(ClusterFile) ->
-    Cluster = wait(erlfdb_nif:create_cluster(ClusterFile)),
-    wait(erlfdb_nif:cluster_create_database(Cluster, <<"DB">>)).
+    erlfdb_nif:create_database(ClusterFile).
 
 
 create_transaction(?IS_DB = Db) ->

--- a/src/erlfdb_nif.erl
+++ b/src/erlfdb_nif.erl
@@ -25,12 +25,7 @@
     future_get_error/1,
     future_get/1,
 
-    create_cluster/0,
-    create_cluster/1,
-    cluster_set_option/2,
-    cluster_set_option/3,
-    cluster_create_database/2,
-
+    create_database/1,
     database_set_option/2,
     database_set_option/3,
     database_create_transaction/1,
@@ -63,12 +58,11 @@
 ]).
 
 
--define(DEFAULT_API_VERSION, 600).
+-define(DEFAULT_API_VERSION, 610).
 
 
 -type error() :: {erlfdb_error, Code::integer()}.
 -type future() :: {erlfdb_future, reference(), reference()}.
--type cluster() :: {erlfdb_cluster, reference()}.
 -type database() :: {erlfdb_database, reference()}.
 -type transaction() :: {erlfdb_transaction, reference()}.
 
@@ -79,7 +73,6 @@
     {Key::binary(), OrEqual::boolean(), Offset::integer()}.
 
 -type future_result() ::
-    cluster() |
     database() |
     integer() |
     binary() |
@@ -91,6 +84,7 @@
     local_address |
     cluster_file |
     trace_enable |
+    trace_format |
     trace_roll_size |
     trace_max_logs_size |
     trace_log_group |
@@ -115,8 +109,6 @@
     disable_local_client |
     disable_client_statistics_logging |
     enable_slow_task_profiling.
-
--type cluster_option() :: there_are_no_cluster_options.
 
 -type database_option() ::
     location_cache_size |
@@ -211,16 +203,11 @@ future_get({erlfdb_future, _Ref, Ft}) ->
     erlfdb_future_get(Ft).
 
 
--spec create_cluster() -> future().
-create_cluster() ->
-    create_cluster(<<0>>).
+-spec create_database(ClusterFilePath::binary()) -> database().
+create_database(<<>>) ->
+    create_database(<<0>>);
 
-
--spec create_cluster(ClusterFilePath::binary()) -> future().
-create_cluster(<<>>) ->
-    create_cluster(<<0>>);
-
-create_cluster(ClusterFilePath) ->
+create_database(ClusterFilePath) ->
     Size = size(ClusterFilePath) - 1,
     % Make sure we pass a NULL-terminated string
     % to FoundationDB
@@ -230,26 +217,7 @@ create_cluster(ClusterFilePath) ->
         _ ->
             <<ClusterFilePath/binary, 0>>
     end,
-    erlfdb_create_cluster(NifPath).
-
-
--spec cluster_set_option(cluster(), Option::cluster_option()) -> ok.
-cluster_set_option(Cluster, Option) ->
-    cluster_set_option(Cluster, Option, <<>>).
-
-
--spec cluster_set_option(
-        cluster(),
-        Option::cluster_option(),
-        Value::option_value()
-    ) -> ok.
-cluster_set_option({erlfdb_cluster, Cluster}, Opt, Value) ->
-    erlfdb_cluster_set_option(Cluster, Opt, Value).
-
-
--spec cluster_create_database(cluster(), DbName::binary()) -> {ok, database()}.
-cluster_create_database({erlfdb_cluster, Cluster}, DbName) ->
-    erlfdb_cluster_create_database(Cluster, DbName).
+    erlfdb_create_database(NifPath).
 
 
 -spec database_set_option(database(), Option::database_option()) -> ok.
@@ -535,12 +503,8 @@ erlfdb_future_is_ready(_Future) -> ?NOT_LOADED.
 erlfdb_future_get_error(_Future) -> ?NOT_LOADED.
 erlfdb_future_get(_Future) -> ?NOT_LOADED.
 
-% Clusters
-erlfdb_create_cluster(_ClusterFile) -> ?NOT_LOADED.
-erlfdb_cluster_set_option(_Cluster, _ClusterOption, _Value) -> ?NOT_LOADED.
-erlfdb_cluster_create_database(_Cluster, _DbName) -> ?NOT_LOADED.
-
 % Databases
+erlfdb_create_database(_ClusterFilePath) -> ?NOT_LOADED.
 erlfdb_database_set_option(_Database, _DatabaseOption, _Value) -> ?NOT_LOADED.
 erlfdb_database_create_transaction(_Database) -> ?NOT_LOADED.
 


### PR DESCRIPTION
There were some changes that had to be accounted for:

 * Cluster is gone, so cluster futures, resources, etc were removed

 * Create database returns a database object not future, so database future
   type is removed.

 * It's possible to use json tracing format on the client, so added that
   netowrk option.