### PR TITLE
Bump API level to 620

### DIFF
--- a/c_src/atom_names.h
+++ b/c_src/atom_names.h
@@ -97,6 +97,7 @@ ATOM_MAP(snapshot_ryw_disable);
 ATOM_MAP(lock_aware);
 ATOM_MAP(used_during_commit_protection_disable);
 ATOM_MAP(read_lock_aware);
+ATOM_MAP(size_limit);
 
 
 // Streaming mode

--- a/c_src/fdb.h
+++ b/c_src/fdb.h
@@ -13,7 +13,7 @@
 #ifndef ERLFDB_FDB_H
 #define ERLFDB_FDB_H
 
-#define FDB_API_VERSION 610
+#define FDB_API_VERSION 620
 #include <foundationdb/fdb_c.h>
 
 #endif // Included fdb.h

--- a/c_src/resources.h
+++ b/c_src/resources.h
@@ -28,7 +28,7 @@ typedef enum _ErlFDBFutureType
 {
     ErlFDB_FT_NONE = 0,
     ErlFDB_FT_VOID,
-    ErlFDB_FT_VERSION,
+    ErlFDB_FT_INT64,
     ErlFDB_FT_KEY,
     ErlFDB_FT_VALUE,
     ErlFDB_FT_STRING_ARRAY,

--- a/src/erlfdb.app.src
+++ b/src/erlfdb.app.src
@@ -18,7 +18,7 @@
     {maintainers, ["Paul J. Davis"]},
     {links, [{"GitHub", "https://github.com/cloudant-labs/couchdb-erlfdb"}]},
     {env, [
-        {api_version, 610},
+        {api_version, 620},
         {network_options, []}
     ]}
 ]}.

--- a/src/erlfdb.erl
+++ b/src/erlfdb.erl
@@ -103,6 +103,9 @@
     get_committed_version/1,
     get_versionstamp/1,
 
+    % Transaction size info
+    get_approximate_size/1,
+
     % Transaction status
     get_next_tx_id/1,
     is_read_only/1,
@@ -566,6 +569,13 @@ get_versionstamp(?IS_TX = Tx) ->
 
 get_versionstamp(?IS_SS = SS) ->
     get_versionstamp(?GET_TX(SS)).
+
+
+get_approximate_size(?IS_TX = Tx) ->
+    erlfdb_nif:transaction_get_approximate_size(Tx);
+
+get_approximate_size(?IS_SS = SS) ->
+    get_approximate_size(?GET_TX(SS)).
 
 
 get_next_tx_id(?IS_TX = Tx) ->

--- a/src/erlfdb_nif.erl
+++ b/src/erlfdb_nif.erl
@@ -52,13 +52,14 @@
     transaction_add_conflict_range/4,
     transaction_get_next_tx_id/1,
     transaction_is_read_only/1,
+    transaction_get_approximate_size/1,
 
     get_error/1,
     error_predicate/2
 ]).
 
 
--define(DEFAULT_API_VERSION, 610).
+-define(DEFAULT_API_VERSION, 620).
 
 
 -type error() :: {erlfdb_error, Code::integer()}.
@@ -140,7 +141,9 @@
     snapshot_ryw_disable |
     lock_aware |
     used_during_commit_protection_disable |
-    read_lock_aware.
+    read_lock_aware |
+    size_limit.
+
 
 -type streaming_mode() ::
     stream_want_all |
@@ -409,6 +412,11 @@ transaction_add_conflict_range(
     erlfdb_transaction_add_conflict_range(Tx, StartKey, EndKey, ConflictType).
 
 
+-spec transaction_get_approximate_size(transaction()) -> non_neg_integer().
+transaction_get_approximate_size({erlfdb_transaction, Tx}) ->
+    erlfdb_transaction_get_approximate_size(Tx).
+
+
 -spec transaction_get_next_tx_id(transaction()) -> non_neg_integer().
 transaction_get_next_tx_id({erlfdb_transaction, Tx}) ->
     erlfdb_transaction_get_next_tx_id(Tx).
@@ -559,6 +567,7 @@ erlfdb_transaction_add_conflict_range(
     ) -> ?NOT_LOADED.
 erlfdb_transaction_get_next_tx_id(_Transaction) -> ?NOT_LOADED.
 erlfdb_transaction_is_read_only(_Transaction) -> ?NOT_LOADED.
+erlfdb_transaction_get_approximate_size(_Transaction) -> ?NOT_LOADED.
 
 
 % Misc

--- a/test/erlfdb_03_transaction_size_test.erl
+++ b/test/erlfdb_03_transaction_size_test.erl
@@ -1,0 +1,39 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(erlfdb_03_transaction_size_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+
+get_approximate_tx_size_test() ->
+    Db1 = erlfdb_util:get_test_db(),
+    erlfdb:transactional(Db1, fun(Tx) ->
+         ok = erlfdb:set(Tx, gen(10), gen(5000)),
+         TxSize1 = erlfdb:wait(erlfdb:get_approximate_size(Tx)),
+         ?assert(TxSize1 > 5000 andalso TxSize1 < 6000),
+         ok = erlfdb:set(Tx, gen(10), gen(5000)),
+         TxSize2 = erlfdb:wait(erlfdb:get_approximate_size(Tx)),
+         ?assert(TxSize2 > 10000)
+    end).
+
+
+size_limit_test() ->
+    Db1 = erlfdb_util:get_test_db(),
+    ?assertError({erlfdb_error, 2101}, erlfdb:transactional(Db1, fun(Tx) ->
+         erlfdb:set_option(Tx, size_limit, 10000),
+         erlfdb:set(Tx, gen(10), gen(11000))
+    end)).
+
+
+gen(Size) ->
+    crypto:strong_rand_bytes(Size).

--- a/test/tester.es
+++ b/test/tester.es
@@ -651,6 +651,11 @@ execute(TxObj, St, <<"GET_VERSIONSTAMP">>) ->
     stack_push(St, VS),
     St;
 
+execute(TxObj, St, <<"GET_APPROXIMATE_SIZE">>) ->
+    erlfdb:wait(erlfdb:get_approximate_size(TxObj)),
+    stack_push(St, <<"GOT_APPROXIMATE_SIZE">>),
+    St;
+
 execute(_TxObj, St, <<"TUPLE_PACK">>) ->
     Count = stack_pop(St),
     Elems = stack_pop(St, Count),


### PR DESCRIPTION
This comes with a few changes:

 * `fdb_future_get_version` was renamed to `fdb_future_get_int64`
 * a new API: `fdb_transaction_get_approximate_size`
 * `size_limit` transaction option

Reference: https://apple.github.io/foundationdb/release-notes.html#bindings