### PR TITLE
Add transaction option to disallow writes

### DIFF
--- a/c_src/atom_names.h
+++ b/c_src/atom_names.h
@@ -33,6 +33,7 @@ ATOM_MAP(erlfdb_transaction);
 
 ATOM_MAP(invalid_future_type);
 
+ATOM_MAP(writes_not_allowed);
 
 // Network Options
 ATOM_MAP(local_address);
@@ -98,6 +99,8 @@ ATOM_MAP(lock_aware);
 ATOM_MAP(used_during_commit_protection_disable);
 ATOM_MAP(read_lock_aware);
 ATOM_MAP(size_limit);
+ATOM_MAP(allow_writes);
+ATOM_MAP(disallow_writes);
 
 
 // Streaming mode

--- a/c_src/resources.h
+++ b/c_src/resources.h
@@ -60,6 +60,7 @@ typedef struct _ErlFDBTransaction
     ERL_NIF_TERM owner;
     unsigned int txid;
     bool read_only;
+    bool writes_allowed;
 } ErlFDBTransaction;
 
 

--- a/src/erlfdb.erl
+++ b/src/erlfdb.erl
@@ -109,6 +109,7 @@
     % Transaction status
     get_next_tx_id/1,
     is_read_only/1,
+    get_writes_allowed/1,
 
     % Locality
     get_addresses_for_key/2,
@@ -590,6 +591,13 @@ is_read_only(?IS_TX = Tx) ->
 
 is_read_only(?IS_SS = SS) ->
     is_read_only(?GET_TX(SS)).
+
+
+get_writes_allowed(?IS_TX = Tx) ->
+    erlfdb_nif:transaction_get_writes_allowed(Tx);
+
+get_writes_allowed(?IS_SS = SS) ->
+    get_writes_allowed(?GET_TX(SS)).
 
 
 get_addresses_for_key(?IS_DB = Db, Key) ->

--- a/src/erlfdb_nif.erl
+++ b/src/erlfdb_nif.erl
@@ -52,6 +52,7 @@
     transaction_add_conflict_range/4,
     transaction_get_next_tx_id/1,
     transaction_is_read_only/1,
+    transaction_get_writes_allowed/1,
     transaction_get_approximate_size/1,
 
     get_error/1,
@@ -142,7 +143,9 @@
     lock_aware |
     used_during_commit_protection_disable |
     read_lock_aware |
-    size_limit.
+    size_limit |
+    allow_writes |
+    disallow_writes.
 
 
 -type streaming_mode() ::
@@ -427,6 +430,11 @@ transaction_is_read_only({erlfdb_transaction, Tx}) ->
     erlfdb_transaction_is_read_only(Tx).
 
 
+-spec transaction_get_writes_allowed(transaction()) -> true | false.
+transaction_get_writes_allowed({erlfdb_transaction, Tx}) ->
+    erlfdb_transaction_get_writes_allowed(Tx).
+
+
 -spec get_error(integer()) -> binary().
 get_error(Error) ->
     erlfdb_get_error(Error).
@@ -567,6 +575,7 @@ erlfdb_transaction_add_conflict_range(
     ) -> ?NOT_LOADED.
 erlfdb_transaction_get_next_tx_id(_Transaction) -> ?NOT_LOADED.
 erlfdb_transaction_is_read_only(_Transaction) -> ?NOT_LOADED.
+erlfdb_transaction_get_writes_allowed(_Transaction) -> ?NOT_LOADED.
 erlfdb_transaction_get_approximate_size(_Transaction) -> ?NOT_LOADED.
 
 

--- a/test/erlfdb_03_transaction_options_test.erl
+++ b/test/erlfdb_03_transaction_options_test.erl
@@ -10,7 +10,7 @@
 % License for the specific language governing permissions and limitations under
 % the License.
 
--module(erlfdb_03_transaction_size_test).
+-module(erlfdb_03_transaction_options_test).
 
 -include_lib("eunit/include/eunit.hrl").
 
@@ -32,6 +32,30 @@ size_limit_test() ->
     ?assertError({erlfdb_error, 2101}, erlfdb:transactional(Db1, fun(Tx) ->
          erlfdb:set_option(Tx, size_limit, 10000),
          erlfdb:set(Tx, gen(10), gen(11000))
+    end)).
+
+
+writes_allowed_test() ->
+    Db1 = erlfdb_util:get_test_db(),
+    ?assertError(writes_not_allowed, erlfdb:transactional(Db1, fun(Tx) ->
+        ?assert(erlfdb:get_writes_allowed(Tx)),
+
+        erlfdb:set_option(Tx, disallow_writes),
+        ?assert(not erlfdb:get_writes_allowed(Tx)),
+
+        erlfdb:set_option(Tx, allow_writes),
+        ?assert(erlfdb:get_writes_allowed(Tx)),
+
+        erlfdb:set_option(Tx, disallow_writes),
+        erlfdb:set(Tx, gen(10), gen(10))
+    end)).
+
+
+once_writes_happend_cannot_disallow_them_test() ->
+    Db1 = erlfdb_util:get_test_db(),
+    ?assertError(badarg, erlfdb:transactional(Db1, fun(Tx) ->
+        ok = erlfdb:set(Tx, gen(10), gen(10)),
+        erlfdb:set_option(Tx, disallow_writes)
     end)).
 
 


### PR DESCRIPTION
Add `disallow_writes | allow_writes` transaction options.

If the transaction hasn't done any writes yet, it is possible to set the
`disallow_writes` option, and then every write attempt will throw a
`writes_not_allowed` error.