### PR TITLE
erlfdb_tuple:encode/2 should handle lists through binary conversion

### DIFF
--- a/src/erlfdb_tuple.erl
+++ b/src/erlfdb_tuple.erl
@@ -252,7 +252,10 @@ encode(Double, _) when is_float(Double) ->
 encode(Tuple, Depth) when is_tuple(Tuple) ->
     Elems = tuple_to_list(Tuple),
     Encoded = [encode(E, Depth + 1) || E <- Elems],
-    [<<?NESTED>>, Encoded, <<?NULL>>].
+    [<<?NESTED>>, Encoded, <<?NULL>>];
+
+encode(BadTerm, _) ->
+    erlang:error({invalid_tuple_term, BadTerm}).
 
 
 enc_null_terminated(Bin) ->


### PR DESCRIPTION
While troubleshooting an issue with `_all_docs` for CouchDB 4.0 I was encountering a `function_clause` error for `erlfdb_tuple:encode/2`.

By inserting some troubleshooting logs it became evident that in some circumstances document _ids can get passed down to `erlfdb_tuple:encode/2` as lists, e.g. `"mydocid"`. Specifically the doc ids I was dealing with were "numbers" e.g. `"687"`.

In CouchDB 3.0 the same requests which failed in 4.0 would succeed. Specifically when the POST method was used with keys in the body, 4.0 would fail. Also, when the keys were URL encoded in a GET `_all_docs` request 4.0 would fail. After this change both succeed. Notably a non-URL encoded keys value used in a 4.0 request would succeed.

I'm not 100% sure if the fix should be here or perhaps in more uniform handling of keys in chttpd (?) i.e. making sure we extract them as binaries.

I'm opening this for discussion and hopefully the fix!